### PR TITLE
Support Qubic-http and fix validation for create bet feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "base-64": "^1.0.0",
+    "buffer": "^6.0.3",
     "clsx": "^1.2.1",
+    "node-fetch": "^3.3.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-icons": "^5.2.1",
@@ -43,6 +46,7 @@
   },
   "devDependencies": {
     "auto-changelog": "^2.4.0",
+    "http-proxy-middleware": "^3.0.0",
     "tailwindcss": "^3.4.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,18 @@ importers:
       '@testing-library/user-event':
         specifier: ^13.5.0
         version: 13.5.0(@testing-library/dom@10.1.0)
+      base-64:
+        specifier: ^1.0.0
+        version: 1.0.0
+      buffer:
+        specifier: ^6.0.3
+        version: 6.0.3
       clsx:
         specifier: ^1.2.1
         version: 1.2.1
+      node-fetch:
+        specifier: ^3.3.2
+        version: 3.3.2
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -48,6 +57,9 @@ importers:
       auto-changelog:
         specifier: ^2.4.0
         version: 2.4.0
+      http-proxy-middleware:
+        specifier: ^3.0.0
+        version: 3.0.0
       tailwindcss:
         specifier: ^3.4.3
         version: 3.4.3
@@ -1784,6 +1796,12 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  base-64@1.0.0:
+    resolution: {integrity: sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   batch@0.6.1:
     resolution: {integrity: sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==}
 
@@ -1837,6 +1855,9 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   builtin-modules@3.3.0:
     resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
@@ -2186,6 +2207,10 @@ packages:
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
 
   data-urls@2.0.0:
     resolution: {integrity: sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==}
@@ -2695,6 +2720,10 @@ packages:
   fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
 
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -2776,6 +2805,10 @@ packages:
   form-data@3.0.1:
     resolution: {integrity: sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==}
     engines: {node: '>= 6'}
+
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -3010,6 +3043,10 @@ packages:
       '@types/express':
         optional: true
 
+  http-proxy-middleware@3.0.0:
+    resolution: {integrity: sha512-36AV1fIaI2cWRzHo+rbcxhe3M3jUDCNzc4D5zRl57sEWRAxdXYtw7FSQKYY6PDKssiAKjLYypbssHk+xs/kMXw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   http-proxy@1.18.1:
     resolution: {integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==}
     engines: {node: '>=8.0.0'}
@@ -3042,6 +3079,9 @@ packages:
   identity-obj-proxy@3.0.0:
     resolution: {integrity: sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==}
     engines: {node: '>=4'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
   ignore@5.3.1:
     resolution: {integrity: sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==}
@@ -3798,6 +3838,10 @@ packages:
   no-case@3.0.4:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
     engines: {node: 4.x || >=6.0.0}
@@ -3806,6 +3850,10 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-forge@1.3.1:
     resolution: {integrity: sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==}
@@ -5374,6 +5422,10 @@ packages:
 
   wbuf@1.7.3:
     resolution: {integrity: sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==}
+
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
 
   web-vitals@2.1.4:
     resolution: {integrity: sha512-sVWcwhU5mX6crfI5Vd2dC4qchyTqxV8URinzt25XqVh+bHEPGH4C3NPrNionCP7Obx59wrYEbNlw4Z8sjALzZg==}
@@ -7874,6 +7926,10 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  base-64@1.0.0: {}
+
+  base64-js@1.5.1: {}
+
   batch@0.6.1: {}
 
   bfj@7.1.0:
@@ -7943,6 +7999,11 @@ snapshots:
       node-int64: 0.4.0
 
   buffer-from@1.1.2: {}
+
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   builtin-modules@3.3.0: {}
 
@@ -8283,6 +8344,8 @@ snapshots:
   csstype@3.1.3: {}
 
   damerau-levenshtein@1.0.8: {}
+
+  data-uri-to-buffer@4.0.1: {}
 
   data-urls@2.0.0:
     dependencies:
@@ -8970,6 +9033,11 @@ snapshots:
     dependencies:
       bser: 2.1.1
 
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
   file-entry-cache@6.0.1:
     dependencies:
       flat-cache: 3.2.0
@@ -9030,7 +9098,9 @@ snapshots:
 
   flatted@3.3.1: {}
 
-  follow-redirects@1.15.6: {}
+  follow-redirects@1.15.6(debug@4.3.5):
+    optionalDependencies:
+      debug: 4.3.5
 
   for-each@0.3.3:
     dependencies:
@@ -9066,6 +9136,10 @@ snapshots:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       mime-types: 2.1.35
+
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
 
   forwarded@0.2.0: {}
 
@@ -9308,7 +9382,7 @@ snapshots:
   http-proxy-middleware@2.0.6(@types/express@4.17.21):
     dependencies:
       '@types/http-proxy': 1.17.14
-      http-proxy: 1.18.1
+      http-proxy: 1.18.1(debug@4.3.5)
       is-glob: 4.0.3
       is-plain-obj: 3.0.0
       micromatch: 4.0.7
@@ -9317,10 +9391,21 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  http-proxy@1.18.1:
+  http-proxy-middleware@3.0.0:
+    dependencies:
+      '@types/http-proxy': 1.17.14
+      debug: 4.3.5
+      http-proxy: 1.18.1(debug@4.3.5)
+      is-glob: 4.0.3
+      is-plain-obj: 3.0.0
+      micromatch: 4.0.7
+    transitivePeerDependencies:
+      - supports-color
+
+  http-proxy@1.18.1(debug@4.3.5):
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.6
+      follow-redirects: 1.15.6(debug@4.3.5)
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -9351,6 +9436,8 @@ snapshots:
   identity-obj-proxy@3.0.0:
     dependencies:
       harmony-reflect: 1.6.2
+
+  ieee754@1.2.1: {}
 
   ignore@5.3.1: {}
 
@@ -10322,9 +10409,17 @@ snapshots:
       lower-case: 2.0.2
       tslib: 2.6.3
 
+  node-domexception@1.0.0: {}
+
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   node-forge@1.3.1: {}
 
@@ -12057,6 +12152,8 @@ snapshots:
   wbuf@1.7.3:
     dependencies:
       minimalistic-assert: 1.0.1
+
+  web-streams-polyfill@3.3.3: {}
 
   web-vitals@2.1.4: {}
 

--- a/src/App.css
+++ b/src/App.css
@@ -4,3 +4,23 @@ html {
   background-color: rgb(16, 24, 32);
   font-family: 'Space Grotesk', sans-serif;
 }
+
+.date-input-wrapper {
+  position: relative;
+  flex: 1;
+}
+
+.date-input-wrapper input[type="date"] {
+  width: 100%;
+  padding-right: 5px;
+  padding-left: 5px;
+  box-sizing: border-box;
+}
+
+.date-input-wrapper .calendar-icon {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+}

--- a/src/components/BetOverviewCard.jsx
+++ b/src/components/BetOverviewCard.jsx
@@ -6,7 +6,9 @@ import LabelData from "./LabelData"
 import { sumArray } from "./qubic/util"
 
 function BetOverviewCard({ data, onClick }) {
-
+  // console.log(data.close_date);
+  // console.log(data.close_time);
+  // console.log('####################', data.close_date + ' ' + data.close_time.slice(0, -3) + ' UTC');
   return (
     <Card
       className="p-[15px] h-[240px] hover:border-primary-40 cursor-pointer"

--- a/src/components/ProvidersList.jsx
+++ b/src/components/ProvidersList.jsx
@@ -1,8 +1,8 @@
-import React, { useEffect, useState } from 'react';
+import React, {useEffect, useState} from 'react';
 import InputMaxChars from './qubic/ui/InputMaxChars';
 import InputRegEx from './qubic/ui/InputRegEx';
 
-const ProvidersList = ({ max, providers: initialProviders, onChange }) => {
+const ProvidersList = ({max, providers: initialProviders, onChange}) => {
   const [providers, setProviders] = useState(initialProviders);
   const [errors, setErrors] = useState({});
 
@@ -13,14 +13,14 @@ const ProvidersList = ({ max, providers: initialProviders, onChange }) => {
   const handleProviderChange = (index, field, value) => {
     const newProviders = [...providers];
     newProviders[index] = { ...newProviders[index], [field]: value };
-    setProviders(newProviders);
-    onChange(newProviders);
+        setProviders(newProviders);
+        onChange(newProviders);
   };
 
   const handleAddProvider = (event) => {
     event.preventDefault();
     if (providers.length < max) {
-      const newProviders = [...providers, { publicId: '', fee: '' }];
+      const newProviders = [...providers, {publicId: '', fee: ''}];
       setProviders(newProviders);
       onChange(newProviders);
     }
@@ -60,6 +60,7 @@ const ProvidersList = ({ max, providers: initialProviders, onChange }) => {
               max={60}
               placeholder="Enter Oracle ID"
               initialValue={provider.publicId}
+              regEx={/^[A-Z]*$/}
               onChange={(value) => handleProviderChange(index, 'publicId', value)}
             />
             {errors[`publicId_${index}`] && <p className="text-red-500">{errors[`publicId_${index}`]}</p>}
@@ -81,8 +82,9 @@ const ProvidersList = ({ max, providers: initialProviders, onChange }) => {
             className="text-red-500 disabled:text-gray-500"
             disabled={providers.length <= 1}
           >
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" className="w-6 h-6">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"
+                 className="w-6 h-6">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12"/>
             </svg>
           </button>
         </div>

--- a/src/components/ProvidersList.jsx
+++ b/src/components/ProvidersList.jsx
@@ -5,6 +5,7 @@ import InputRegEx from './qubic/ui/InputRegEx';
 const ProvidersList = ({max, providers: initialProviders, onChange}) => {
   const [providers, setProviders] = useState(initialProviders);
   const [errors, setErrors] = useState({});
+  const [totalFeeError, setTotalFeeError] = useState('')
 
   useEffect(() => {
     setProviders(initialProviders);
@@ -12,10 +13,24 @@ const ProvidersList = ({max, providers: initialProviders, onChange}) => {
 
   const handleProviderChange = (index, field, value) => {
     const newProviders = [...providers];
-    newProviders[index] = { ...newProviders[index], [field]: value };
-        setProviders(newProviders);
-        onChange(newProviders);
+    newProviders[index] = {...newProviders[index], [field]: value};
+    setProviders(newProviders);
+    onChange(newProviders);
+    validateFees(newProviders);
+
   };
+
+  const validateFees = (providerList) => {
+    const totalFees = providerList.reduce((sum, provider) => {
+      return sum + (parseFloat(provider.fee) || 0);
+    }, 0)
+
+    if (totalFees > 100) {
+      setTotalFeeError('The total sum of provider fees cannot exceed 100%.')
+    } else {
+      setTotalFeeError('')
+    }
+  }
 
   const handleAddProvider = (event) => {
     event.preventDefault();
@@ -30,6 +45,7 @@ const ProvidersList = ({max, providers: initialProviders, onChange}) => {
     const newProviders = providers.filter((_, i) => i !== index);
     setProviders([...newProviders]);
     onChange(newProviders);
+    validateFees(newProviders)
   };
 
   useEffect(() => {
@@ -47,6 +63,7 @@ const ProvidersList = ({max, providers: initialProviders, onChange}) => {
       return Object.keys(newErrors).length === 0;
     };
     validateProviders();
+    validateFees(providers)
   }, [providers]);
 
   return (

--- a/src/components/qubic/connect/QubicConnectContext.jsx
+++ b/src/components/qubic/connect/QubicConnectContext.jsx
@@ -77,7 +77,7 @@ export function QubicConnectProvider({ children }) {
       tx[offset + i] = 0
     }
     offset += i - 1
-    txView.setBigInt64(offset, BigInt(bet.amountPerSlot * bet.numberOfSlots), true); // amount per slot
+    txView.setBigInt64(offset, BigInt(bet.amountPerSlot * BigInt(bet.numberOfSlots)), true); // amount per slot
     offset += 8
     txView.setUint32(offset, tick + tickOffset, true)
     offset += 4

--- a/src/components/qubic/ui/InputMaxChars.jsx
+++ b/src/components/qubic/ui/InputMaxChars.jsx
@@ -1,19 +1,20 @@
 import React, { useEffect, useState, forwardRef, useImperativeHandle } from 'react';
 
-const InputMaxChars = forwardRef(({ id, label, max, placeholder, initialValue = '', onChange }, ref) => {
+const InputMaxChars = forwardRef(({ id, label, max, placeholder, initialValue = '', regEx = /.*/, onChange }, ref) => {
   const [value, setValue] = useState(initialValue);
   const [numChars, setNumChars] = useState(initialValue.length);
   const [error, setError] = useState('');
 
   const handleChange = (event) => {
     const newValue = event.target.value;
-    if (newValue.length > max) {
-      setError(`Maximum ${max} characters allowed`);
-    } else {
+
+    if (regEx.test(newValue) && newValue.length <= max) {
       setError('');
       setNumChars(newValue.length);
       setValue(newValue);
       onChange(newValue);
+    } else if (newValue.length > max) {
+      setError(`Maximum ${max} characters allowed`);
     }
   };
 

--- a/src/components/qubic/ui/InputNumbers.jsx
+++ b/src/components/qubic/ui/InputNumbers.jsx
@@ -1,19 +1,24 @@
-import React, { useState, forwardRef, useImperativeHandle } from 'react';
+import React, {useState, forwardRef, useImperativeHandle} from 'react';
 import LabelWithPopover from './LabelWithPopover';
 
-const InputNumbers = forwardRef(({ id, label, placeholder, description, onChange }, ref) => {
+const InputNumbers = forwardRef(({id, label, placeholder, description, maxLimit = Infinity, onChange}, ref) => {
   const [value, setValue] = useState('');
   const [error, setError] = useState('');
 
   const handleChange = (e) => {
     const newValue = e.target.value;
-    setValue(newValue);
-    if (newValue === '') {
-      setError('This field is required');
-    } else {
+
+    const regEx = /^[0-9]*$/;
+
+    if (regEx.test(newValue) && Number(newValue) <= maxLimit && Number(newValue) >= 0) {
+      setValue(newValue);
       setError('');
+      onChange(newValue);
+    } else if (Number(newValue) > maxLimit) {
+      setError(`Value must be less than or equal to ${maxLimit}`);
+    } else {
+      setError('Invalid input');
     }
-    onChange(newValue);
   };
 
   useImperativeHandle(ref, () => ({
@@ -22,17 +27,21 @@ const InputNumbers = forwardRef(({ id, label, placeholder, description, onChange
         setError('This field is required');
         return false;
       }
+      if (Number(value) > maxLimit) {
+        setError(`Value must be less than or equal to ${maxLimit}`);
+        return false;
+      }
       setError('');
       return true;
     }
-  }))
+  }));
 
   return (
     <div>
-      <LabelWithPopover label={label} description={description} />
+      <LabelWithPopover label={label} description={description}/>
       <input
         id={id}
-        type="number"
+        type="text"  // change to "text" to prevent "e" input, while using regex for validation
         className={`w-full p-4 bg-gray-80 border border-gray-70 text-white rounded-lg placeholder-gray-500 ${error && 'border-red-500'}`}
         placeholder={placeholder}
         value={value}

--- a/src/components/qubic/ui/SelectDateTime.jsx
+++ b/src/components/qubic/ui/SelectDateTime.jsx
@@ -5,10 +5,12 @@ const SelectDateTime = forwardRef(({ label, fieldId, onChange }, ref) => {
   const [selectedHours, setSelectedHours] = useState('');
   const [selectedMinutes, setSelectedMinutes] = useState('');
   const [error, setError] = useState('');
+  const [keyboardWarning, setKeyboardWarning] = useState('');
 
   const handleDateChange = (event) => {
     const date = event.target.value;
     setSelectedDate(date);
+    setKeyboardWarning('');
     notifyChange(date, selectedHours, selectedMinutes);
   };
 
@@ -54,15 +56,19 @@ const SelectDateTime = forwardRef(({ label, fieldId, onChange }, ref) => {
       <label className="block text-white mb-2">{label}</label>
       <div className="flex space-x-2">
         {/* Date Field */}
-        <div className="flex-1 relative">
+        <div className="date-input-wrapper">
           <input
             id={`${fieldId}-date`}
             type="date"
             className="w-full p-4 bg-gray-80 border border-gray-70 text-white rounded-lg placeholder-gray-500"
             placeholder="Select date"
             onChange={handleDateChange}
+            onKeyDown={(e) => {
+              e.preventDefault();
+              setKeyboardWarning('Please select a date from the calendar button');
+            }}
           />
-          <div className="absolute inset-y-0 right-4 flex items-center pointer-events-none">
+          <div className="calendar-icon">
             <svg
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
@@ -118,6 +124,8 @@ const SelectDateTime = forwardRef(({ label, fieldId, onChange }, ref) => {
           </select>
         </div>
       </div>
+
+      {keyboardWarning && <p className="text-yellow-500 text-right text-sm">{keyboardWarning}</p>}
       {error && <p className="text-red-500 text-right text-sm">{error}</p>}
     </div>
   );

--- a/src/components/qubic/util/betApi.js
+++ b/src/components/qubic/util/betApi.js
@@ -1,0 +1,220 @@
+// utils/betApi.js
+import {Buffer} from 'buffer';
+import base64 from 'base-64';
+import {HEADERS, makeJsonData, QTRY_CONTRACT_INDEX, QUERY_SMART_CONTRACT_API_URI} from './commons';
+
+// Get Node's info using qubic-http's API
+export const fetchNodeInfo = async () => {
+  const jsonData = makeJsonData(QTRY_CONTRACT_INDEX, 1, 0, "");
+
+  const response = await fetch(QUERY_SMART_CONTRACT_API_URI, {
+    method: 'POST',
+    headers: HEADERS,
+    body: JSON.stringify(jsonData),
+  });
+
+  const responseData = await response.json();
+  const data = base64.decode(responseData.responseData);
+  const buffer = Buffer.from(data, 'binary');
+
+  // Unpacking data using DataView
+  const dataView = new DataView(buffer.buffer);
+
+  const feePerSlotPerHour = dataView.getBigUint64(0, true);
+  const gameOperatorFee = dataView.getBigUint64(8, true);
+  const shareholderFee = dataView.getBigUint64(16, true);
+  const minBetSlotAmount = dataView.getBigUint64(24, true);
+  const burnFee = dataView.getBigUint64(32, true);
+  const nIssuedBet = dataView.getUint32(40, true);
+  // Skipping 4 bytes due to padding, so the next byte offset must be 48
+  const moneyFlow = dataView.getBigUint64(48, true);
+  const moneyFlowThroughIssueBet = dataView.getBigUint64(56, true);
+  const moneyFlowThroughJoinBet = dataView.getBigUint64(64, true);
+  const moneyFlowThroughFinalizeBet = dataView.getBigUint64(72, true);
+  const earnedAmountForShareholder = dataView.getBigUint64(80, true);
+  const paidAmountForShareholder = dataView.getBigUint64(88, true);
+  const earnedAmountForBetWinner = dataView.getBigUint64(96, true);
+  const distributedAmount = dataView.getBigUint64(104, true);
+  const burnedAmount = dataView.getBigUint64(112, true);
+
+  // This is Game operator public key, which is 32 bytes, converting it to Uint8Array
+  // for later qubicHelper.getidentity() decoding.
+  const gameOperatorBytes = new Uint8Array(buffer.slice(120, 152)); // 32 bytes
+
+  // Returning the unpacked data
+  return {
+    fee_per_slot_per_hour: Number(feePerSlotPerHour),
+    game_operator_fee: Number(gameOperatorFee),
+    shareholder_fee: Number(shareholderFee),
+    min_bet_slot_amount: Number(minBetSlotAmount),
+    burn_fee: Number(burnFee),
+    n_issued_bet: nIssuedBet,
+    money_flow: Number(moneyFlow),
+    money_flow_through_issue_bet: Number(moneyFlowThroughIssueBet),
+    money_flow_through_join_bet: Number(moneyFlowThroughJoinBet),
+    money_flow_through_finalize_bet: Number(moneyFlowThroughFinalizeBet),
+    earned_amount_for_shareholder: Number(earnedAmountForShareholder),
+    paid_amount_for_shareholder: Number(paidAmountForShareholder),
+    earned_amount_for_bet_winner: Number(earnedAmountForBetWinner),
+    distributed_amount: Number(distributedAmount),
+    burned_amount: Number(burnedAmount),
+    game_operator: gameOperatorBytes,
+  };
+};
+
+
+// Fetch bets considered "active" by Quottery core (not reached end dates)
+// In the frontend/UI, "active" bets haven't reached close dates,
+// "locked" bets haven't reached end dates, and "inactive" bets have exceeded end dates.
+// This function retrieves Quottery core active bet IDs using the qubic-http API.
+export const fetchActiveBets = async () => {
+  const json_data = makeJsonData(QTRY_CONTRACT_INDEX, 4, 0, '');
+
+  const response = await fetch(QUERY_SMART_CONTRACT_API_URI, {
+    method: 'POST',
+    headers: HEADERS,
+    body: JSON.stringify(json_data),
+  });
+
+
+  const responseData = await response.json();
+  const data = base64.decode(responseData.responseData);
+
+  // Use Buffer to handle binary data
+  const buffer = Buffer.from(data, 'binary');
+
+  // Read the count of active bets (first 4 bytes as UInt32)
+  const count = buffer.readUInt32LE(0);
+
+  // Extract active bet IDs from the rest of the buffer
+  const activeBetIds = [];
+  for (let i = 0; i < count; i++) {
+    activeBetIds.push(buffer.readUInt32LE(4 + i * 4));
+  }
+
+  return activeBetIds;
+};
+
+
+const parseFixedSizeStrings = (buffer, start, length, count, itemSize) => {
+  // const items_ = [length];
+  const items = [];
+  for (let i = 0; i < count; i++) {
+    const str = buffer.slice(start + i * itemSize, start + (i + 1) * itemSize).toString('utf-8');
+    items.push(str.replace(/\0/g, '').trim()); // Remove null characters and trim whitespace
+  }
+  return items;
+};
+
+// Function to unpack Quottery date
+const unpackQuotteryDate = (data) => {
+  const year = ((data >> 26) & 0x3F) + 24;
+  const month = (data >> 22) & 0x0F;
+  const day = (data >> 17) & 0x1F;
+  const hour = (data >> 12) & 0x1F;
+  const minute = (data >> 6) & 0x3F;
+  const second = data & 0x3F;
+
+  return {year, month, day, hour, minute, second};
+}
+
+const calculateBettingOdds = (currentNumSelection) => {
+  const totalSelections = currentNumSelection.reduce((acc, val) => acc + val, 0);
+
+  // Initialize betting_odds as an array of "1.0"
+  let betting_odds = Array(currentNumSelection.length).fill("1.0");
+
+  if (totalSelections > 0) {
+    betting_odds = currentNumSelection.map(selection =>
+      selection > 0 ? (totalSelections / selection).toString() : totalSelections.toString()
+    );
+  }
+
+  return betting_odds;
+};
+
+const formatQuotteryDate = (dateObj) => {
+  if (!dateObj) return 'N/A';
+  const year = dateObj.year.toString().padStart(2, '0');
+  const month = dateObj.month.toString().padStart(2, '0');
+  const day = dateObj.day.toString().padStart(2, '0');
+  const hour = dateObj.hour.toString().padStart(2, '0');
+  const minute = dateObj.minute.toString().padStart(2, '0');
+
+  // Format the date and time similar to the old API structure
+  return {
+    date: `${year}-${month}-${day}`,
+    time: `${hour}:${minute}:00`
+  };
+};
+
+const bufferToUint8Array = (buffer) => {
+  return new Uint8Array(buffer);
+};
+
+// Function to fetch details of a specific bet given the bet id
+export const fetchBetDetail = async (betId) => {
+  const betIdBuffer = Buffer.alloc(4);
+  betIdBuffer.writeUInt32LE(betId, 0);
+  const inputBase64 = base64.encode(betIdBuffer);
+
+  const json_data = makeJsonData(QTRY_CONTRACT_INDEX, 2, 4, inputBase64);
+
+  const response = await fetch(QUERY_SMART_CONTRACT_API_URI, {
+    method: 'POST',
+    headers: HEADERS,
+    body: JSON.stringify(json_data),
+  });
+
+  const responseData = await response.json();
+  const data = base64.decode(responseData.responseData);
+  const buffer = Buffer.from(data, 'binary');
+
+  const nOption = buffer.readUInt32LE(4);
+  const openDateRaw = unpackQuotteryDate(buffer.readUInt32LE(616));
+  const closeDateRaw = unpackQuotteryDate(buffer.readUInt32LE(620));
+  const endDateRaw = unpackQuotteryDate(buffer.readUInt32LE(624));
+
+  const openDate = formatQuotteryDate(openDateRaw);
+  const closeDate = formatQuotteryDate(closeDateRaw);
+  const endDate = formatQuotteryDate(endDateRaw);
+
+  const creator = bufferToUint8Array(buffer.slice(8, 40));
+
+  const amountPerBetSlot = buffer.readBigUInt64LE(632); // Read uint64 minBetAmount
+
+  // Parse and filter oracleProviderId to remove empty strings
+  const oracleProviderId = parseFixedSizeStrings(buffer, 328, 256, 8, 32)
+    .map(id => bufferToUint8Array(Buffer.from(id, 'utf-8')))
+    .filter(id => id.length > 0); // Filter out empty strings
+
+  const oracleFees = Array.from({length: oracleProviderId.length}, (_, i) => buffer.readUInt32LE(584 + i * 4) / 100);
+  const currentNumSelection = Array.from({length: nOption}, (_, i) => buffer.readUInt32LE(648 + i * 4));
+
+  const bettingOdds = calculateBettingOdds(currentNumSelection);
+
+  // Define unpacking logic for bet details using Buffer
+  return {
+    bet_id: buffer.readUInt32LE(0), // Read uint32 betId
+    nOption: nOption, // Read uint32 nOption
+    creator: creator,
+    bet_desc: buffer.slice(40, 72).toString('utf-8').replace(/\0/g, '').trim(), // Read and clean 32-byte bet description
+    option_desc: parseFixedSizeStrings(buffer, 72, 256, 8, 32).filter(id => id.length > 0), // Parse 8x 32-byte option descriptions
+    oracle_id: oracleProviderId,
+    oracle_fee: oracleFees,
+    open_date: openDate.date,
+    close_date: closeDate.date,
+    end_date: endDate.date,
+    open_time: openDate.time,
+    close_time: closeDate.time,
+    end_time: endDate.time,
+    amount_per_bet_slot: amountPerBetSlot,
+    maxBetSlotPerOption: buffer.readUInt32LE(640),
+    current_bet_state: currentNumSelection,
+    current_num_selection: currentNumSelection,
+    betResultWonOption: Array.from({length: oracleProviderId.length}, (_, i) => buffer.readInt8(680 + i)),
+    betResultOPId: Array.from({length: oracleProviderId.length}, (_, i) => buffer.readInt8(688 + i)),
+    current_total_qus: currentNumSelection.reduce((acc, val) => acc + val, 0) * Number(amountPerBetSlot),
+    betting_odds: bettingOdds,
+  };
+};

--- a/src/components/qubic/util/betApi.js
+++ b/src/components/qubic/util/betApi.js
@@ -220,7 +220,7 @@ export const fetchBetDetail = async (betId, maxRetryCount = 3) => {
         .filter(id => id.length > 0); // Filter out empty strings
 
       const oracleFees = Array.from({ length: oracleProviderId.length }, (_, i) => buffer.readUInt32LE(584 + i * 4) / 100);
-      const currentNumSelection = Array.from({ length: nOption }, (_, i) => buffer.readUInt32LE(648 + i * 4));
+      const currentNumSelection = Array.from({ length: nOption }, (_, i) => buffer.readUInt32LE(644 + i * 4));
 
       const bettingOdds = calculateBettingOdds(currentNumSelection);
 

--- a/src/components/qubic/util/betApi.js
+++ b/src/components/qubic/util/betApi.js
@@ -1,65 +1,91 @@
 // utils/betApi.js
 import {Buffer} from 'buffer';
 import base64 from 'base-64';
-import {HEADERS, makeJsonData, QTRY_CONTRACT_INDEX, QUERY_SMART_CONTRACT_API_URI} from './commons';
+import {HEADERS, makeJsonData, QTRY_CONTRACT_INDEX, QUERY_SMART_CONTRACT_API_URI, backendUrl} from './commons';
 
 // Get Node's info using qubic-http's API
 export const fetchNodeInfo = async () => {
-  const jsonData = makeJsonData(QTRY_CONTRACT_INDEX, 1, 0, "");
+  try {
+    const jsonData = makeJsonData(QTRY_CONTRACT_INDEX, 1, 0, "");
 
-  const response = await fetch(QUERY_SMART_CONTRACT_API_URI, {
-    method: 'POST',
-    headers: HEADERS,
-    body: JSON.stringify(jsonData),
-  });
+    const response = await fetch(QUERY_SMART_CONTRACT_API_URI, {
+      method: 'POST',
+      headers: HEADERS,
+      body: JSON.stringify(jsonData),
+    });
 
-  const responseData = await response.json();
-  const data = base64.decode(responseData.responseData);
-  const buffer = Buffer.from(data, 'binary');
+    // Check if the response is not ok (status is not 200-299)
+    if (!response.ok) {
+      throw new Error(`Error fetching node info: ${response.status} ${response.statusText}`);
+    }
 
-  // Unpacking data using DataView
-  const dataView = new DataView(buffer.buffer);
+    const responseData = await response.json();
+    const data = base64.decode(responseData.responseData);
+    const buffer = Buffer.from(data, 'binary');
 
-  const feePerSlotPerHour = dataView.getBigUint64(0, true);
-  const gameOperatorFee = dataView.getBigUint64(8, true);
-  const shareholderFee = dataView.getBigUint64(16, true);
-  const minBetSlotAmount = dataView.getBigUint64(24, true);
-  const burnFee = dataView.getBigUint64(32, true);
-  const nIssuedBet = dataView.getUint32(40, true);
-  // Skipping 4 bytes due to padding, so the next byte offset must be 48
-  const moneyFlow = dataView.getBigUint64(48, true);
-  const moneyFlowThroughIssueBet = dataView.getBigUint64(56, true);
-  const moneyFlowThroughJoinBet = dataView.getBigUint64(64, true);
-  const moneyFlowThroughFinalizeBet = dataView.getBigUint64(72, true);
-  const earnedAmountForShareholder = dataView.getBigUint64(80, true);
-  const paidAmountForShareholder = dataView.getBigUint64(88, true);
-  const earnedAmountForBetWinner = dataView.getBigUint64(96, true);
-  const distributedAmount = dataView.getBigUint64(104, true);
-  const burnedAmount = dataView.getBigUint64(112, true);
+    // Unpacking data using DataView
+    const dataView = new DataView(buffer.buffer);
 
-  // This is Game operator public key, which is 32 bytes, converting it to Uint8Array
-  // for later qubicHelper.getidentity() decoding.
-  const gameOperatorBytes = new Uint8Array(buffer.slice(120, 152)); // 32 bytes
+    const feePerSlotPerHour = dataView.getBigUint64(0, true);
+    const gameOperatorFee = dataView.getBigUint64(8, true);
+    const shareholderFee = dataView.getBigUint64(16, true);
+    const minBetSlotAmount = dataView.getBigUint64(24, true);
+    const burnFee = dataView.getBigUint64(32, true);
+    const nIssuedBet = dataView.getUint32(40, true);
+    // Skipping 4 bytes due to padding, so the next byte offset must be 48
+    const moneyFlow = dataView.getBigUint64(48, true);
+    const moneyFlowThroughIssueBet = dataView.getBigUint64(56, true);
+    const moneyFlowThroughJoinBet = dataView.getBigUint64(64, true);
+    const moneyFlowThroughFinalizeBet = dataView.getBigUint64(72, true);
+    const earnedAmountForShareholder = dataView.getBigUint64(80, true);
+    const paidAmountForShareholder = dataView.getBigUint64(88, true);
+    const earnedAmountForBetWinner = dataView.getBigUint64(96, true);
+    const distributedAmount = dataView.getBigUint64(104, true);
+    const burnedAmount = dataView.getBigUint64(112, true);
 
-  // Returning the unpacked data
-  return {
-    fee_per_slot_per_hour: Number(feePerSlotPerHour),
-    game_operator_fee: Number(gameOperatorFee),
-    shareholder_fee: Number(shareholderFee),
-    min_bet_slot_amount: Number(minBetSlotAmount),
-    burn_fee: Number(burnFee),
-    n_issued_bet: nIssuedBet,
-    money_flow: Number(moneyFlow),
-    money_flow_through_issue_bet: Number(moneyFlowThroughIssueBet),
-    money_flow_through_join_bet: Number(moneyFlowThroughJoinBet),
-    money_flow_through_finalize_bet: Number(moneyFlowThroughFinalizeBet),
-    earned_amount_for_shareholder: Number(earnedAmountForShareholder),
-    paid_amount_for_shareholder: Number(paidAmountForShareholder),
-    earned_amount_for_bet_winner: Number(earnedAmountForBetWinner),
-    distributed_amount: Number(distributedAmount),
-    burned_amount: Number(burnedAmount),
-    game_operator: gameOperatorBytes,
-  };
+    // This is Game operator public key, which is 32 bytes, converting it to Uint8Array
+    // for later qubicHelper.getidentity() decoding.
+    const gameOperatorBytes = new Uint8Array(buffer.slice(120, 152)); // 32 bytes
+
+    // Returning the unpacked data
+    return {
+      fee_per_slot_per_hour: Number(feePerSlotPerHour),
+      game_operator_fee: Number(gameOperatorFee),
+      shareholder_fee: Number(shareholderFee),
+      min_bet_slot_amount: Number(minBetSlotAmount),
+      burn_fee: Number(burnFee),
+      n_issued_bet: nIssuedBet,
+      money_flow: Number(moneyFlow),
+      money_flow_through_issue_bet: Number(moneyFlowThroughIssueBet),
+      money_flow_through_join_bet: Number(moneyFlowThroughJoinBet),
+      money_flow_through_finalize_bet: Number(moneyFlowThroughFinalizeBet),
+      earned_amount_for_shareholder: Number(earnedAmountForShareholder),
+      paid_amount_for_shareholder: Number(paidAmountForShareholder),
+      earned_amount_for_bet_winner: Number(earnedAmountForBetWinner),
+      distributed_amount: Number(distributedAmount),
+      burned_amount: Number(burnedAmount),
+      game_operator: gameOperatorBytes,
+    };
+
+  } catch (error) {
+    console.error('Error in fetchNodeInfo:', error.message);
+    console.log('Falling back to old API for node info.');
+
+    // Fallback to old API
+    try {
+      const response = await fetch(`${backendUrl}/get_all_bets`);
+      const data = await response.json();
+
+      if (data.node_info) {
+        return data.node_info[0];
+      } else {
+        throw new Error('Node info not found in old API response');
+      }
+    } catch (fallbackError) {
+      console.error('Error fetching node info from old API:', fallbackError.message);
+      throw fallbackError; // Re-throwing the error for handling later in the caller
+    }
+  }
 };
 
 
@@ -153,68 +179,85 @@ const bufferToUint8Array = (buffer) => {
 };
 
 // Function to fetch details of a specific bet given the bet id
-export const fetchBetDetail = async (betId) => {
+export const fetchBetDetail = async (betId, maxRetryCount = 3) => {
   const betIdBuffer = Buffer.alloc(4);
   betIdBuffer.writeUInt32LE(betId, 0);
   const inputBase64 = base64.encode(betIdBuffer);
 
   const json_data = makeJsonData(QTRY_CONTRACT_INDEX, 2, 4, inputBase64);
+  for (let attempt = 0; attempt < maxRetryCount; attempt++) {
+    try {
+      const response = await fetch(QUERY_SMART_CONTRACT_API_URI, {
+        method: 'POST',
+        headers: HEADERS,
+        body: JSON.stringify(json_data),
+      });
 
-  const response = await fetch(QUERY_SMART_CONTRACT_API_URI, {
-    method: 'POST',
-    headers: HEADERS,
-    body: JSON.stringify(json_data),
-  });
+      if (!response.ok) {
+        throw new Error(`Error fetching bet details: ${response.status} ${response.statusText}`);
+      }
 
-  const responseData = await response.json();
-  const data = base64.decode(responseData.responseData);
-  const buffer = Buffer.from(data, 'binary');
+      const responseData = await response.json();
+      const data = base64.decode(responseData.responseData);
+      const buffer = Buffer.from(data, 'binary');
 
-  const nOption = buffer.readUInt32LE(4);
-  const openDateRaw = unpackQuotteryDate(buffer.readUInt32LE(616));
-  const closeDateRaw = unpackQuotteryDate(buffer.readUInt32LE(620));
-  const endDateRaw = unpackQuotteryDate(buffer.readUInt32LE(624));
+      const nOption = buffer.readUInt32LE(4);
+      const openDateRaw = unpackQuotteryDate(buffer.readUInt32LE(616));
+      const closeDateRaw = unpackQuotteryDate(buffer.readUInt32LE(620));
+      const endDateRaw = unpackQuotteryDate(buffer.readUInt32LE(624));
 
-  const openDate = formatQuotteryDate(openDateRaw);
-  const closeDate = formatQuotteryDate(closeDateRaw);
-  const endDate = formatQuotteryDate(endDateRaw);
+      const openDate = formatQuotteryDate(openDateRaw);
+      const closeDate = formatQuotteryDate(closeDateRaw);
+      const endDate = formatQuotteryDate(endDateRaw);
 
-  const creator = bufferToUint8Array(buffer.slice(8, 40));
+      const creator = bufferToUint8Array(buffer.slice(8, 40));
 
-  const amountPerBetSlot = buffer.readBigUInt64LE(632); // Read uint64 minBetAmount
+      const amountPerBetSlot = buffer.readBigUInt64LE(632); // Read uint64 minBetAmount
 
-  // Parse and filter oracleProviderId to remove empty strings
-  const oracleProviderId = parseFixedSizeStrings(buffer, 328, 256, 8, 32)
-    .map(id => bufferToUint8Array(Buffer.from(id, 'utf-8')))
-    .filter(id => id.length > 0); // Filter out empty strings
+      // Parse and filter oracleProviderId to remove empty strings
+      const oracleProviderId = parseFixedSizeStrings(buffer, 328, 256, 8, 32)
+        .map(id => bufferToUint8Array(Buffer.from(id, 'utf-8')))
+        .filter(id => id.length > 0); // Filter out empty strings
 
-  const oracleFees = Array.from({length: oracleProviderId.length}, (_, i) => buffer.readUInt32LE(584 + i * 4) / 100);
-  const currentNumSelection = Array.from({length: nOption}, (_, i) => buffer.readUInt32LE(648 + i * 4));
+      const oracleFees = Array.from({length: oracleProviderId.length}, (_, i) => buffer.readUInt32LE(584 + i * 4) / 100);
+      const currentNumSelection = Array.from({length: nOption}, (_, i) => buffer.readUInt32LE(648 + i * 4));
 
-  const bettingOdds = calculateBettingOdds(currentNumSelection);
+      const bettingOdds = calculateBettingOdds(currentNumSelection);
 
-  // Define unpacking logic for bet details using Buffer
-  return {
-    bet_id: buffer.readUInt32LE(0), // Read uint32 betId
-    nOption: nOption, // Read uint32 nOption
-    creator: creator,
-    bet_desc: buffer.slice(40, 72).toString('utf-8').replace(/\0/g, '').trim(), // Read and clean 32-byte bet description
-    option_desc: parseFixedSizeStrings(buffer, 72, 256, 8, 32).filter(id => id.length > 0), // Parse 8x 32-byte option descriptions
-    oracle_id: oracleProviderId,
-    oracle_fee: oracleFees,
-    open_date: openDate.date,
-    close_date: closeDate.date,
-    end_date: endDate.date,
-    open_time: openDate.time,
-    close_time: closeDate.time,
-    end_time: endDate.time,
-    amount_per_bet_slot: amountPerBetSlot,
-    maxBetSlotPerOption: buffer.readUInt32LE(640),
-    current_bet_state: currentNumSelection,
-    current_num_selection: currentNumSelection,
-    betResultWonOption: Array.from({length: oracleProviderId.length}, (_, i) => buffer.readInt8(680 + i)),
-    betResultOPId: Array.from({length: oracleProviderId.length}, (_, i) => buffer.readInt8(688 + i)),
-    current_total_qus: currentNumSelection.reduce((acc, val) => acc + val, 0) * Number(amountPerBetSlot),
-    betting_odds: bettingOdds,
-  };
+      // Define unpacking logic for bet details using Buffer
+      return {
+        bet_id: buffer.readUInt32LE(0), // Read uint32 betId
+        nOption: nOption, // Read uint32 nOption
+        creator: creator,
+        bet_desc: buffer.slice(40, 72).toString('utf-8').replace(/\0/g, '').trim(), // Read and clean 32-byte bet description
+        option_desc: parseFixedSizeStrings(buffer, 72, 256, 8, 32).filter(id => id.length > 0), // Parse 8x 32-byte option descriptions
+        oracle_id: oracleProviderId,
+        oracle_fee: oracleFees,
+        open_date: openDate.date,
+        close_date: closeDate.date,
+        end_date: endDate.date,
+        open_time: openDate.time,
+        close_time: closeDate.time,
+        end_time: endDate.time,
+        amount_per_bet_slot: amountPerBetSlot,
+        maxBetSlotPerOption: buffer.readUInt32LE(640),
+        current_bet_state: currentNumSelection,
+        current_num_selection: currentNumSelection,
+        betResultWonOption: Array.from({length: oracleProviderId.length}, (_, i) => buffer.readInt8(680 + i)),
+        betResultOPId: Array.from({length: oracleProviderId.length}, (_, i) => buffer.readInt8(688 + i)),
+        current_total_qus: currentNumSelection.reduce((acc, val) => acc + val, 0) * Number(amountPerBetSlot),
+        betting_odds: bettingOdds,
+      };
+
+    } catch (error) {
+      console.error(`Attempt ${attempt + 1}: Error fetching bet details for betId ${betId} - ${error.message}`);
+
+      if (attempt === maxRetryCount - 1) {
+        console.error('Max retry attempts reached. Failing gracefully.');
+        throw error;  // Re-throw the error after the final attempt
+      }
+
+      console.log('Retrying...');
+    }
+  }
 };

--- a/src/components/qubic/util/commons.js
+++ b/src/components/qubic/util/commons.js
@@ -8,7 +8,7 @@ export const HEADERS = {
 };
 
 export const QTRY_CONTRACT_INDEX = 2;
-
+export const excludedBetIds = []
 export const makeJsonData = (contractIndex, inputType, inputSize, requestData) => {
   return {
     contractIndex: contractIndex,

--- a/src/components/qubic/util/commons.js
+++ b/src/components/qubic/util/commons.js
@@ -1,6 +1,6 @@
 // src/components/qubic/commons.js
 
-export const QUERY_SMART_CONTRACT_API_URI = 'https://testapi.qubic.org/v1/querySmartContract';
+export const QUERY_SMART_CONTRACT_API_URI = 'https://rpc.qubic.org/v1/querySmartContract';
 
 export const HEADERS = {
   'accept': 'application/json',

--- a/src/components/qubic/util/commons.js
+++ b/src/components/qubic/util/commons.js
@@ -1,0 +1,19 @@
+// src/components/qubic/commons.js
+
+export const QUERY_SMART_CONTRACT_API_URI = 'https://testapi.qubic.org/v1/querySmartContract';
+
+export const HEADERS = {
+  'accept': 'application/json',
+  'Content-Type': 'application/json',
+};
+
+export const QTRY_CONTRACT_INDEX = 2;
+
+export const makeJsonData = (contractIndex, inputType, inputSize, requestData) => {
+  return {
+    contractIndex: contractIndex,
+    inputType: inputType,
+    inputSize: inputSize,
+    requestData: requestData,
+  };
+};

--- a/src/components/qubic/util/commons.js
+++ b/src/components/qubic/util/commons.js
@@ -19,4 +19,4 @@ export const makeJsonData = (contractIndex, inputType, inputSize, requestData) =
 };
 
 export const backendUrl = 'https://qbtn.qubic.org' // test system
-// const backendUrl = 'https://qb.qubic.org' // live system
+// export const backendUrl = 'https://qb.qubic.org' // live system

--- a/src/components/qubic/util/commons.js
+++ b/src/components/qubic/util/commons.js
@@ -17,3 +17,6 @@ export const makeJsonData = (contractIndex, inputType, inputSize, requestData) =
     requestData: requestData,
   };
 };
+
+export const backendUrl = 'https://qbtn.qubic.org' // test system
+// const backendUrl = 'https://qb.qubic.org' // live system

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
+import './App.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 

--- a/src/pages/BetCreatePage.jsx
+++ b/src/pages/BetCreatePage.jsx
@@ -98,7 +98,7 @@ function BetCreatePage() {
             id="description"
             ref={descriptionRef}
             label="Bet description"
-            max={100}
+            max={32}
             placeholder="Enter bet description"
             onChange={(value) => {
               setBet({ ...bet, description: value })

--- a/src/pages/BetCreatePage.jsx
+++ b/src/pages/BetCreatePage.jsx
@@ -85,7 +85,7 @@ function BetCreatePage() {
 
   return (
     <div className='mt-[90px] sm:px-30 md:px-130'>
-      <div className="max-w-md mx-auto p-4">
+      <div className="max-w-3xl mx-auto p-4">
 
         <FormHead
           title='Create New Bet'
@@ -165,6 +165,7 @@ function BetCreatePage() {
             placeholder="Enter max bet slots"
             description="Here we go with a small help description."
             ref={maxBetSlotsRef}
+            maxLimit={1024}
             onChange={handleMaxBetSlotsChange}
           />
 

--- a/src/pages/BetDetailsPage.jsx
+++ b/src/pages/BetDetailsPage.jsx
@@ -11,6 +11,7 @@ import ConfirmTxModal from '../components/qubic/connect/ConfirmTxModal'
 import { sumArray } from '../components/qubic/util'
 import { fetchBetDetail } from '../components/qubic/util/betApi'
 import {QubicHelper} from "@qubic-lib/qubic-ts-library/dist/qubicHelper";
+import {excludedBetIds} from '../components/qubic/util/commons'
 /* global BigInt */
 
 function BetDetailsPage() {
@@ -78,13 +79,20 @@ function BetDetailsPage() {
   const updateBetDetails = async () => {
     try {
       setLoading(true)
+
+      if (excludedBetIds.includes(parseInt(id))) {
+        setBet(null)
+        setLoading(false)
+        navigate('/')
+        return
+      }
+
       const updatedBet = await fetchBetDetail(parseInt(id))
 
-      // Recalculate current_total_qus and betting_odds if needed
       updatedBet.current_total_qus = sumArray(updatedBet.current_num_selection) * Number(updatedBet.amount_per_bet_slot)
       updatedBet.betting_odds = calculateBettingOdds(updatedBet.current_num_selection)
 
-      updatedBet.creator = await qHelper.getIdentity(updatedBet.creator); // Update creator field with human-readable identity
+      updatedBet.creator = await qHelper.getIdentity(updatedBet.creator)
       updatedBet.oracle_id = await Promise.all(
         updatedBet.oracle_id.map(async (oracleId) => {
           return await qHelper.getIdentity(oracleId);

--- a/src/pages/BetDetailsPage.jsx
+++ b/src/pages/BetDetailsPage.jsx
@@ -26,9 +26,9 @@ function BetDetailsPage() {
 
   const updateAmountOfBetSlots = (value) => {
     // check if value is not less than 1 and not greater than max_slot_per_option
-    if (value < 1 || value > bet.max_slot_per_option) return
+    if (value < 1 || value > bet.maxBetSlotPerOption) return
     // valid value
-    setOptionCosts(BigInt(value) * bet.amount_per_bet_slot)
+    setOptionCosts(BigInt(value) * BigInt(bet.amount_per_bet_slot))
     setAmountOfBetSlots(value)
   }
 
@@ -218,9 +218,9 @@ function BetDetailsPage() {
               </span>
               <span
                 className='font-space text-gray-50 text-[12px] leading-[16px] block mt-3 text-right underline cursor-pointer'
-                onClick={() => updateAmountOfBetSlots(bet.max_slot_per_option)}
+                onClick={() => updateAmountOfBetSlots(bet.maxBetSlotPerOption)}
               >
-                Go for Max ({bet.max_slot_per_option})
+                Go for Max ({bet.maxBetSlotPerOption})
               </span>
             </Card>
           }

--- a/src/pages/BetDetailsPage.jsx
+++ b/src/pages/BetDetailsPage.jsx
@@ -9,6 +9,7 @@ import LabelData from '../components/LabelData'
 import { useQubicConnect } from '../components/qubic/connect/QubicConnectContext'
 import ConfirmTxModal from '../components/qubic/connect/ConfirmTxModal'
 import { sumArray } from '../components/qubic/util'
+/* global BigInt */
 
 function BetDetailsPage() {
   const { id } = useParams()
@@ -27,7 +28,7 @@ function BetDetailsPage() {
     // check if value is not less than 1 and not greater than max_slot_per_option
     if (value < 1 || value > bet.max_slot_per_option) return
     // valid value
-    setOptionCosts(value * bet.amount_per_bet_slot)
+    setOptionCosts(BigInt(value) * bet.amount_per_bet_slot)
     setAmountOfBetSlots(value)
   }
 

--- a/src/pages/StartPage.jsx
+++ b/src/pages/StartPage.jsx
@@ -3,6 +3,8 @@ import { useNavigate } from 'react-router-dom'
 import BetOverviewCard from '../components/BetOverviewCard'
 import Dropdown from '../components/qubic/Dropdown'
 import { useQuotteryContext } from '../contexts/QuotteryContext'
+import {excludedBetIds} from '../components/qubic/util/commons'
+
 
 function StartPage() {
   const navigate = useNavigate()
@@ -54,7 +56,9 @@ function StartPage() {
         {loading && <div>Loading...</div>}
 
         {!loading && state.bets && state.bets.length > 0 && <>
-          {state.bets.map((bet, index) =>
+          {state.bets
+            .filter(bet => !excludedBetIds.includes(bet.bet_id))
+            .map((bet, index) =>
             <BetOverviewCard
               key={'bet' + index}
               data={bet}


### PR DESCRIPTION
# New Fetch Bet mechanism
- Support qubic-http for active/locked bet fetching & get node info
- All bet fetching will trigger both qubic-http and BE
- When qubic-http is unavailable, auto retry and fallback to using BE
- Only use BE for historical bet or when qubic-http is unavailable

# Minor Create Bet Validation Fix
- Oracle Provider ID must be just A-Z chars
- Amount of Qus per slot must be just integer from 0-9, no scientific input, no negative, no floating point.
- Max bet slot is the same as Amount of Qus per slot, but it cannot exceed 1024.
- Prevent the user from typing on the date input field, as they can input wrong date time format. Only allow input from the calendar button.
- Fix the padding for the calendar button on Safari from overlapping with the input field.

@couch42 @AndyQus 