### PR TITLE
Feat/check balance

### DIFF
--- a/src/components/BetCreateConfirm.jsx
+++ b/src/components/BetCreateConfirm.jsx
@@ -83,7 +83,9 @@ const BetCreateConfirm = ({ bet }) => {
           {hasEnoughBalance ? (
             <></>// <p className="text-green-500">You have enough balance to create this bet.</p>
           ) : (
-            <p className="text-red-500">You do not have enough balance to create this bet.</p>
+            <p className="text-red-500">
+              {`You do not have enough balance to create this bet. Your balance: ${formatQubicAmount(balance)} Qubic${balance > 1 ? 's' : ''}, bet creation fee: ${formatQubicAmount(bet.costs)} Qubic${bet.costs > 1 ? 's' : ''}`}
+            </p>
           )}
         </div>
       )}

--- a/src/components/qubic/connect/ConfirmTxModal.jsx
+++ b/src/components/qubic/connect/ConfirmTxModal.jsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react"
 import Card from "../Card"
 import { useQubicConnect } from "./QubicConnectContext"
 
-const ConfirmTxModal = ({ tx, open, onClose, onConfirm }) => {
+const ConfirmTxModal = ({ tx, open, onClose, onConfirm, onTransactionComplete }) => {
     const { getTick } = useQubicConnect()
     const [confirmedTx, setConfirmedTx] = useState(null)
     const [initialTick, setInitialTick] = useState(null)
@@ -32,9 +32,14 @@ const ConfirmTxModal = ({ tx, open, onClose, onConfirm }) => {
             const targetTick = confirmedTx.targetTick;
             const normalizedTick = ((tick - initialTick) / (targetTick - initialTick)) * 100;
             const widthPercentage = Math.min(Math.max(normalizedTick, 0), 100);
-            if (widthPercentage >= 100) onClose()
+            if (widthPercentage >= 100) {
+              if (onTransactionComplete) {
+                onTransactionComplete() // call the callback when transaction is complete
+              }
+              onClose()
+            }
         }
-    }, [tick, confirmedTx, initialTick, onClose])
+    }, [tick, confirmedTx, initialTick, onClose, onTransactionComplete])
 
     const startTickFetchInterval = async (cTx) => {
         cTx.targetTick = cTx.targetTick + 2 // Add 2 to target tick to make sure backend fetches data

--- a/src/components/qubic/connect/ConnectLink.jsx
+++ b/src/components/qubic/connect/ConnectLink.jsx
@@ -33,7 +33,7 @@ const ConnectLink = () => {
             <span>Lock Wallet</span>
           </span>
           {balance && (
-            <div className={`text-white mt-2 text-[14px] cursor-pointer ${isNotEnoughFund ? 'text-red font-bold animate-blink' : 'text-white'}`}
+            <div className={`hidden md:block text-white mt-2 text-[14px] cursor-pointer ${isNotEnoughFund ? 'text-red font-bold' : 'text-white'}`}
                  onClick={handleBalanceClick}
                  title={isNotEnoughFund ? "Please deposit funds into your account" : "Click to refresh balance"}
             >

--- a/src/components/qubic/connect/ConnectLink.jsx
+++ b/src/components/qubic/connect/ConnectLink.jsx
@@ -4,6 +4,7 @@ import ConnectModal from "./ConnectModal"
 import {useQubicConnect} from "./QubicConnectContext"
 import {useQuotteryContext} from '../../../contexts/QuotteryContext'
 import {formatQubicAmount} from "../util"
+import {MIN_BALANCE_THRESHOLD} from "../util/commons"
 
 const ConnectLink = () => {
   const {connected, showConnectModal, toggleConnectModal} = useQubicConnect()
@@ -18,6 +19,8 @@ const ConnectLink = () => {
 
   console.log('balance:', balance)
 
+  const isNotEnoughFund = parseInt(balance) <= MIN_BALANCE_THRESHOLD
+
   return (<>
     <div className="absolute right-12 sm:right-12 flex gap-[10px] justify-center items-center cursor-pointer"
          onClick={() => toggleConnectModal()}
@@ -30,9 +33,9 @@ const ConnectLink = () => {
             <span>Lock Wallet</span>
           </span>
           {balance && (
-            <div className="text-white mt-2 text-[14px] cursor-pointer"
+            <div className={`text-white mt-2 text-[14px] cursor-pointer ${isNotEnoughFund ? 'text-red font-bold animate-blink' : 'text-white'}`}
                  onClick={handleBalanceClick}
-                 title="Click to refresh balance"
+                 title={isNotEnoughFund ? "Please deposit funds into your account" : "Click to refresh balance"}
             >
               Balance: {formatQubicAmount(balance)} QUBIC
             </div>

--- a/src/components/qubic/connect/ConnectLink.jsx
+++ b/src/components/qubic/connect/ConnectLink.jsx
@@ -26,7 +26,7 @@ const ConnectLink = () => {
          onClick={() => toggleConnectModal()}
     >
       {connected ? <>
-        <div className="flex flex-col items-center">
+        <div className="hidden md:block flex flex-col items-center">
           <span
             className='hidden md:flex font-space items-center flex-row text-[16px] text-gray-50 mt-[5px] font-[500]'>
             <img src={lock} alt="locked lock icon" className="mr-2"/>
@@ -40,6 +40,13 @@ const ConnectLink = () => {
               Balance: {formatQubicAmount(balance)} QUBIC
             </div>
           )}
+        </div>
+
+        <div className="md:hidden">
+          <span className='hidden md:block font-space text-[16px] text-gray-50 mt-[5px] font-[500]'>
+          Lock Wallet
+        </span>
+          <img src={lock} alt="locked lock icon" />
         </div>
       </> : <>
         <span className='hidden md:block font-space text-[16px] text-gray-50 mt-[5px] font-[500]'>

--- a/src/components/qubic/connect/ConnectLink.jsx
+++ b/src/components/qubic/connect/ConnectLink.jsx
@@ -1,27 +1,49 @@
 import lock from "../../../assets/lock.svg"
 import unlocked from "../../../assets/unlocked.svg"
 import ConnectModal from "./ConnectModal"
-import { useQubicConnect } from "./QubicConnectContext"
+import {useQubicConnect} from "./QubicConnectContext"
+import {useQuotteryContext} from '../../../contexts/QuotteryContext'
+import {formatQubicAmount} from "../util"
 
 const ConnectLink = () => {
-  const { connected, showConnectModal, toggleConnectModal } = useQubicConnect()
+  const {connected, showConnectModal, toggleConnectModal} = useQubicConnect()
+  const {balance, fetchBalance, walletPublicIdentity} = useQuotteryContext()
+
+  const handleBalanceClick = (e) => {
+    e.stopPropagation()
+    if (walletPublicIdentity) {
+      fetchBalance(walletPublicIdentity)
+    }
+  }
+
+  console.log('balance:', balance)
 
   return (<>
     <div className="absolute right-12 sm:right-12 flex gap-[10px] justify-center items-center cursor-pointer"
-      onClick={() => toggleConnectModal()}
+         onClick={() => toggleConnectModal()}
     >
       {connected ? <>
-        <span className='hidden md:block font-space text-[16px] text-gray-50 mt-[5px] font-[500]'>
-          Lock Wallet
-        </span>
-        <img src={lock} alt="locked lock icon" />
+        <div className="flex flex-col items-center">
+          <span
+            className='hidden md:flex font-space items-center flex-row text-[16px] text-gray-50 mt-[5px] font-[500]'>
+            <img src={lock} alt="locked lock icon" className="mr-2"/>
+            <span>Lock Wallet</span>
+          </span>
+          {balance && (
+            <div className="text-white mt-2 text-[14px] cursor-pointer"
+                 onClick={handleBalanceClick}
+                 title="Click to refresh balance"
+            >
+              Balance: {formatQubicAmount(balance)} QUBIC
+            </div>
+          )}
+        </div>
       </> : <>
         <span className='hidden md:block font-space text-[16px] text-gray-50 mt-[5px] font-[500]'>
           Unlock Wallet
         </span>
-        <img src={unlocked} alt="unlocked lock icon" />
-      </>
-      }
+        <img src={unlocked} alt="unlocked lock icon"/>
+      </>}
     </div>
     <ConnectModal
       open={showConnectModal}

--- a/src/components/qubic/util/commons.js
+++ b/src/components/qubic/util/commons.js
@@ -8,7 +8,8 @@ export const HEADERS = {
   'Content-Type': 'application/json',
 };
 
-export const QTRY_CONTRACT_INDEX = 2;
+export const MIN_BALANCE_THRESHOLD = 100
+export const QTRY_CONTRACT_INDEX = 2
 export const LOG_DEBUG = false
 export const excludedBetIds = [31, 34, 58]
 export const makeJsonData = (contractIndex, inputType, inputSize, requestData) => {
@@ -17,8 +18,8 @@ export const makeJsonData = (contractIndex, inputType, inputSize, requestData) =
     inputType: inputType,
     inputSize: inputSize,
     requestData: requestData,
-  };
-};
+  }
+}
 
 // Compare between two Uint8Array
 export const bytesEqual = (a, b) => {

--- a/src/pages/BetCreatePage.jsx
+++ b/src/pages/BetCreatePage.jsx
@@ -222,6 +222,14 @@ function BetCreatePage() {
     }
   }
 
+  const handleTransactionComplete = async () => {
+    if (walletPublicIdentity) {
+      await fetchBalance(walletPublicIdentity) // Fetch the latest balance
+    }
+    // fetchBets('active')
+    // navigate('/')
+  }
+
   useEffect(() => {
     if (balance !== null && bet.costs) {
       setHasEnoughBalance(BigInt(balance) >= BigInt(bet.costs))
@@ -342,6 +350,7 @@ function BetCreatePage() {
         onConfirm={async () => {
           return await signIssueBetTx(bet)
         }}
+        onTransactionComplete={handleTransactionComplete}
       />
     </div>
   )

--- a/src/pages/BetCreatePage.jsx
+++ b/src/pages/BetCreatePage.jsx
@@ -13,6 +13,7 @@ import BetCreateConfirm from '../components/BetCreateConfirm'
 import {useQuotteryContext} from "../contexts/QuotteryContext"
 import {QubicHelper} from "@qubic-lib/qubic-ts-library/dist/qubicHelper"
 import {hashBetData, hashUniqueData} from "../components/qubic/util/hashUtils"
+import {formatQubicAmount} from "../components/qubic/util"
 
 function BetCreatePage() {
 
@@ -200,7 +201,7 @@ function BetCreatePage() {
         }
 
         if (balance !== null && BigInt(balance) < BigInt(betCreationFee)) {
-          alert(`You do not have enough balance to create this bet. Your balance: ${balance}, bet creation fee: ${betCreationFee}`)
+          alert(`You do not have enough balance to create this bet. Your balance: ${formatQubicAmount(balance)} Qubic${balance > 1 ? 's' : ''}, bet creation fee: ${formatQubicAmount(betCreationFee)} Qubic${betCreationFee > 1 ? 's' : ''}`)
           return
         }
 

--- a/src/pages/BetDetailsPage.jsx
+++ b/src/pages/BetDetailsPage.jsx
@@ -221,6 +221,13 @@ function BetDetailsPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id, coreNodeBetIds])
 
+  const handleTransactionComplete = async () => {
+    if (walletPublicIdentity) {
+      await fetchBalance(walletPublicIdentity)
+    }
+    // updateBetDetails()
+  }
+
   useEffect(() => {
     if (balance !== null) {
       setHasEnoughBalance(BigInt(balance) >= BigInt(optionCosts))
@@ -423,7 +430,7 @@ function BetDetailsPage() {
 
         {/** Bet Now button */}
         <div className='
-          fixed h-[78px] flex w-full z-5 bottom-0 gap-3
+          fixed h-[88px] flex w-full z-5 bottom-0 gap-3
           border-t border-solid border-gray-70 bg-gray-90
         '>
           <button className='bg-[rgba(26,222,245,0.1)] flex-none py-[8px] px-[16px] text-18 text-primary-40 font-space'
@@ -433,14 +440,16 @@ function BetDetailsPage() {
           </button>
           <div className='flex-1 flex flex-col justify-center text-center'>
             <BetOptionCosts costs={optionCosts}/>
-            {!hasEnoughBalance && (
-              <p className="text-red-500 mt-2">You do not have enough balance to proceed.</p>
-            )}
+            {/*{!hasEnoughBalance && (*/}
+            {/*  <p className="text-red-500 mt-2">*/}
+            {/*    {`You do not have enough balance to proceed.`}*/}
+            {/*  </p>*/}
+            {/*)}*/}
           </div>
           <button
             className='flex-none bg-primary-40 py-[8px] px-10 text-18 disabled:bg-slate-50 disabled:text-gray-50'
             onClick={handleBetNowClick}
-            disabled={optionCosts === 0 || !hasEnoughBalance}
+            disabled={optionCosts === 0}
           >
             {connected ? 'Bet!' : 'Bet!'}
           </button>
@@ -464,6 +473,7 @@ function BetDetailsPage() {
               })
               return confirmed
             }}
+            onTransactionComplete={handleTransactionComplete}
           />
         </div>
       </>}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,6 +12,14 @@ module.exports = {
   content: ["./src/**/*.{js,jsx,ts,tsx}"],
   theme: {
     extend: {
+      keyframes: {
+        blink: {
+          '50%': { opacity: '0' },
+        },
+      },
+      animation: {
+        blink: 'blink 1s infinite',
+      },
       colors: ({ colors }) => ({
         inherit: colors.inherit,
         current: colors.current,


### PR DESCRIPTION
- Check the account's balance before proceeding with the transaction (join bet and create bet), and prevent the user from proceeding if there is not enough balance. Display a clear message indicating the required amount to proceed.
- Display the user's balance right below the connect link icon (the lock/unlock icon). Currently, this feature is only available for desktop.